### PR TITLE
Remove double buffer in random speed mode

### DIFF
--- a/src/GameSetup.py
+++ b/src/GameSetup.py
@@ -27,6 +27,7 @@ class Setup:
 
     def create_game(self):
         self.args_stuff()
+        self.game.ugly = self.logic.ugly
         return self.game
 
     def refresh_game(self, color_num):

--- a/src/GameWindow.py
+++ b/src/GameWindow.py
@@ -19,6 +19,7 @@ class Window:
         self.direction_symbol_map = {Direction.RIGHT: chr(9654), Direction.LEFT: chr(9664),
                                      Direction.UP: chr(9650), Direction.DOWN: chr(9660)}
         self.buffer_direction = {0: Direction.RIGHT, 1: None}
+        self.ugly = False
 
     def setup(self):
         curses.noecho()
@@ -75,7 +76,7 @@ class Window:
             self.buffer_direction[1] = None
         elif self.buffer_direction[0] is None:
             self.buffer_direction[0] = direction
-        elif self.buffer_direction[1] is None:
+        elif self.buffer_direction[1] is None and not self.ugly:
             self.buffer_direction[1] = direction
         else:
             pass


### PR DESCRIPTION
I noticed that the random speed mode is way to easy with the double buffer, because the random speed does not have any effect on how well the player hits the food, if the double buffer exists. That's why I removed it.